### PR TITLE
Updated dependencies to build with GHC 9.10 & Cabal 3.12

### DIFF
--- a/cabal-hoogle.cabal
+++ b/cabal-hoogle.cabal
@@ -24,23 +24,23 @@ source-repository head
 library
   build-depends:
     , base                  >=4.14     && <5
-    , Cabal                 ^>=3.10
-    , cabal-install         ^>=3.10
-    , Cabal-syntax          ^>=3.10
+    , Cabal                 >=3.10     && <3.14
+    , cabal-install         >=3.10     && <3.14
+    , Cabal-syntax          >=3.10     && <3.14
     , co-log-core           >=0.2      && <0.4
-    , containers            ^>=0.6.2.1
-    , directory             ^>=1.3.6
-    , extra                 ^>=1.7.10
-    , filepath              ^>=1.4.2
+    , containers            >=0.6      && <0.8
+    , directory             ^>=1.3
+    , extra                 ^>=1.7
+    , filepath              >=1.4.2    && <1.6
     , hoogle                ^>=5.0.18
     , lens                  >=5        && <6
     , optparse-applicative  >=0.16     && <1
-    , regex-tdfa            ^>=1.3.1
-    , string-interpolate    ^>=0.3.1.2
-    , text                  ^>=1.2.4   || ^>=2.0
+    , regex-tdfa            ^>=1.3
+    , string-interpolate    ^>=0.3
+    , text                  ^>=1.2.4   || >=2.0 && <2.2
     , time                  >=1.10     && <2
     , transformers          ^>=0.5.6   || ^>=0.6
-    , typed-process         ^>=0.2.10
+    , typed-process         >=0.2.10   && <0.2.13
 
   default-language:   Haskell2010
   ghc-options:        -Wall
@@ -77,8 +77,8 @@ test-suite tests
   build-depends:
     , base
     , cabal-hoogle
-    , silently      ^>=1.2.5.2
-    , tasty         ^>=1.4.2.3
-    , tasty-hunit   ^>=0.10.0.3
+    , silently      ^>=1.2.5
+    , tasty         >=1.4       && <1.6 
+    , tasty-hunit   ^>=0.10
 
   build-tool-depends: tasty-discover:tasty-discover


### PR DESCRIPTION
Hi there,

Thanks for making this package!

This PR is about updating the upper bound on dependencies such that this package can be used with GHC 9.10 and Cabal 3.12