### PR TITLE
Update for Cabal 3.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         cabal:
           - "3.12.1.0"
           - "3.14.2.0"
+          - "3.16.1.0"
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/cabal-hoogle.cabal
+++ b/cabal-hoogle.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cabal-hoogle
-version:            3.14.0.0
+version:            3.16.0.0
 synopsis:           generate hoogle database for cabal project and dependencies
 description:
   Please see the README on GitHub at <https://github.com/kokobd/cabal-hoogle>
@@ -24,9 +24,9 @@ source-repository head
 library
   build-depends:
     , base                  >=4.17    && <4.23
-    , Cabal                 >=3.10    && <3.15
-    , cabal-install         >=3.10    && <3.15
-    , Cabal-syntax          >=3.10    && <3.15
+    , Cabal                 >=3.10    && <3.17
+    , cabal-install         >=3.10    && <3.17
+    , Cabal-syntax          >=3.10    && <3.17
     , co-log-core           >=0.2     && <0.4
     , containers            >=0.6     && <0.8
     , directory             ^>=1.3
@@ -40,7 +40,7 @@ library
     , text                  ^>=1.2.4  || ^>=2.0  || ^>=2.1
     , time                  >=1.10    && <2
     , transformers          ^>=0.5.6  || ^>=0.6
-    , typed-process         >=0.2.10  && <0.2.13
+    , typed-process         >=0.2.10  && <0.2.14
 
   default-language:   Haskell2010
   ghc-options:        -Wall

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707619277,
-        "narHash": "sha256-vKnYD5GMQbNQyyQm4wRlqi+5n0/F1hnvqSQgaBy4BqY=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3a93440fbfff8a74350f4791332a19282cc6dc8",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,42 +4,66 @@
 
     flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = inputs@{ nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    inputs@{ nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
-        compilers = [ "ghc92" "ghc94" "ghc96" ];
-        defaultCompiler = "ghc94";
+        compilers = [
+          "ghc94"
+          "ghc96"
+          "ghc98"
+          "ghc910"
+          "ghc912"
+        ];
+        defaultCompiler = "ghc912";
 
-        mkShell = compiler: pkgs.mkShell {
-          buildInputs = with pkgs; [
-            zlib.dev
-          ];
-          packages = with pkgs; [
-            cabal-install
-            haskell.compiler.${compiler}
-            ormolu
-            miniserve
-          ] ++ (with haskell.packages.${compiler};
-            (lib.lists.optional (compiler != "ghc96") haskell-language-server) ++
-              [ cabal-fmt ghcid ]
-          );
-          shellHook = ''
-            export CABAL_DIR=$(pwd)/.cabal
-            export CABAL_CONFIG=$(pwd)/.cabal/config
-          '';
-        };
+        mkShell =
+          compiler:
+          pkgs.mkShell {
+            buildInputs = with pkgs; [
+              zlib.dev
+            ];
+            packages =
+              with pkgs;
+              [
+                cabal-install
+                haskell.compiler.${compiler}
+                ormolu
+                miniserve
+              ]
+              ++ (
+                with haskell.packages.${compiler};
+                (lib.lists.optional (
+                  !(builtins.elem compiler [
+                    "ghc96"
+                  ])
+                ) haskell-language-server)
+                ++ (lib.lists.optional (
+                  !(builtins.elem compiler [
+                    "ghc912"
+                  ])
+                ) cabal-fmt)
+                ++ [
+                  ghcid
+                ]
+              );
+            shellHook = ''
+              export CABAL_DIR=$(pwd)/.cabal
+              export CABAL_CONFIG=$(pwd)/.cabal/config
+            '';
+          };
       in
       {
         devShells = {
           default = mkShell defaultCompiler;
-        } // builtins.listToAttrs (
-          builtins.map
-            (compiler: {
-              name = compiler;
-              value = mkShell compiler;
-            })
-            compilers
+        }
+        // builtins.listToAttrs (
+          builtins.map (compiler: {
+            name = compiler;
+            value = mkShell compiler;
+          }) compilers
         );
       }
     );


### PR DESCRIPTION
Updates this package to allow for cabal 3.16

The import update comes from the guidance here:
https://github.com/haskell/cabal/blob/7da2987abb234a9710d290568ee90de37d5742e1/release-notes/Cabal-3.16.0.0.md#migration-guide

Other minor updates:
 - Allow typed-process 0.2.13, which appears to be a [minor bugfix](https://github.com/fpco/typed-process/blob/9e08c32913d0bc52be149988328dd5ba374b938d/ChangeLog.md#02130)
 - Adds ghc 9.12 to the flake.nix to line up with the tests
 - nix-rfc-format of flake.nix